### PR TITLE
Allow extra headers when creating messages or streams (anthropic-beta header)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ $anthropic->messages()->maxTokens(2048)->create($messages);
 
 All other optional [options](https://docs.anthropic.com/claude/reference/messages_post) can be set in the same ways.
 
+To include additional HTTP headers in the request, such as those required for enabling extended token limits, pass an array as the second argument to the `create()` method. For example, to enable support for 8192 max tokens:
+
+```php
+$response = Anthropic::messages()->create($query, [ 'anthropic-beta' => 'max-tokens-3-5-sonnet-2024-07-15' ]);
+```
+
 #### Stream
 
 A streamed response follows all of the same options as `create()` but may be invoked with:
@@ -57,6 +63,8 @@ while (! $stream->eof()) {
     flush();
 }
 ```
+
+You may set extra HTTP headers by passing an array as a second argument to `stream()`.
 
 ## Laravel
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -21,24 +21,25 @@ class Client
         ]);
     }
 
-    public function post(string $endpoint, array $args): ResponseInterface|ErrorResponse
+    public function post(string $endpoint, array $args, array $extraHeaders = []): ResponseInterface|ErrorResponse
     {
         try {
             return $this->client->post($endpoint, [
                 'json' => $args,
+                'headers' => array_merge($this->client->getConfig('headers'), $extraHeaders),
             ]);
         } catch (RequestException $e) {
             $this->badRequest($e);
         }
-
     }
 
-    public function stream(string $endpoint, array $args): StreamResponse
+    public function stream(string $endpoint, array $args, array $extraHeaders = []): StreamResponse
     {
         try {
             $response = $this->client->post($endpoint, [
                 'json' => $args,
                 'stream' => true,
+                'headers' => array_merge($this->client->getConfig('headers'), $extraHeaders),
             ]);
 
             return new StreamResponse($response);

--- a/src/Resources/MessagesResource.php
+++ b/src/Resources/MessagesResource.php
@@ -100,22 +100,22 @@ class MessagesResource extends APIResource
         return $this;
     }
 
-    public function create(array $options = []): Response
+    public function create(array $options = [], array $extraHeaders = []): Response
     {
         $this->validateOptions($options);
-        $res = $this->client->post($this->endpoint, $this->request());
+        $res = $this->client->post($this->endpoint, $this->request(), $extraHeaders);
 
         return new MessageResponse($res);
     }
 
-    public function stream(array $options = []): StreamResponse
+    public function stream(array $options = [], array $extraHeaders = []): StreamResponse
     {
         $this->validateOptions($options);
 
         return $this->client->stream($this->endpoint, [
             ...$this->request(),
             'stream' => true,
-        ]);
+        ], $extraHeaders);
     }
 
     private function request(): array


### PR DESCRIPTION
This PR enables support for extra headers such as `anthropic-beta` which can be used to enable support for 8192 token sampling as specified [here](https://x.com/alexalbert__/status/1812921642143900036).

The README file has been updated to explain how it works.