### PR TITLE
Change Method Visibility of request() at MessageResource and Rename It

### DIFF
--- a/src/Resources/MessagesResource.php
+++ b/src/Resources/MessagesResource.php
@@ -103,7 +103,7 @@ class MessagesResource extends APIResource
     public function create(array $options = []): Response
     {
         $this->validateOptions($options);
-        $res = $this->client->post($this->endpoint, $this->request());
+        $res = $this->client->post($this->endpoint, $this->getRequest());
 
         return new MessageResponse($res);
     }
@@ -113,12 +113,12 @@ class MessagesResource extends APIResource
         $this->validateOptions($options);
 
         return $this->client->stream($this->endpoint, [
-            ...$this->request(),
+            ...$this->getRequest(),
             'stream' => true,
         ]);
     }
 
-    private function request(): array
+    public function getRequest(): array
     {
         $optional = array_filter([
             'system' => $this->system,


### PR DESCRIPTION
Hi,

Sometimes is useful for observability and tracing mechanisms to have a grasp about the parameters being sent to the provider.

This changes the method visibility of request() at MessageResource.php from `private` to `public` and also renames it to `getRequest()` to avoid confusion with create() or stream().

Bests,